### PR TITLE
Accept `?` char as terminator for parsing route params

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ let addPath = (router, method, args) => {
 
             let regexpPath = path
                 // Catch params
-                .replace(/:(\w+)/gi, '([^\\s\\/]+)')
+                .replace(/:(\w+)/gi, '([^\\s\\/|\\?]+)')
                 // To set to any url with the path as prefix
                 .replace(/\*/g, '.*')
                 // Remove the last slash


### PR DESCRIPTION
This change allows correct route param parsing in situations where the URL does not have a trailing slash but does have a query string.

**Current Behaviour:**

```js
router.get('/forms/:form_id', async (req, res) => { })

// Request comes in to `/forms/b8359d24-8859-4cfc-8cc5-237338d6a485?utm_source=foobar`

req.params = {
  form_id: 'b8359d24-8859-4cfc-8cc5-237338d6a485?utm_source=foobar'
}
req.query = {
  utm_source: 'foobar'
}
```

**Desired Behaviour:**

```js
router.get('/forms/:form_id', async (req, res) => { })

// Request comes in to `/forms/b8359d24-8859-4cfc-8cc5-237338d6a485?utm_source=foobar`

req.params = {
  form_id: 'b8359d24-8859-4cfc-8cc5-237338d6a485'
}
req.query = {
  utm_source: 'foobar'
}
```